### PR TITLE
Fix minimization of symbolic dfa.

### DIFF
--- a/tests/test_symbolic_automaton.py
+++ b/tests/test_symbolic_automaton.py
@@ -9,6 +9,7 @@ from sympy import Symbol
 from sympy.logic.boolalg import BooleanTrue
 
 from pythomata import SymbolicAutomaton
+from pythomata.impl.symbolic import SymbolicDFA
 from pythomata.simulator import AutomatonSimulator
 from .strategies import propositional_words
 
@@ -405,6 +406,42 @@ class TestMinimize:
     def test_states(self):
         # the renaming of the states is non deterministic, so we need to compare every substructure.
         assert self.minimized.size == 4
+
+    @given(propositional_words(list("abc"), min_size=0, max_size=5))
+    def test_accepts(self, word):
+        """Test equivalence of acceptance between the two automata."""
+        assert self.automaton.accepts(word) == self.minimized.accepts(word)
+
+    def test_minimized_is_complete(self):
+        """Test that every minimized DFA is complete."""
+        assert self.minimized.is_complete()
+
+
+class TestMinimizeWhenNoAcceptingState:
+    @classmethod
+    def setup_class(cls):
+        """Set the tests up."""
+        cls.automaton = SymbolicDFA()
+        automaton = cls.automaton
+        q0 = automaton.create_state()
+        q1 = automaton.create_state()
+        q2 = automaton.create_state()
+        q3 = automaton.create_state()
+        q4 = automaton.create_state()
+
+        automaton.set_initial_state(q0)
+        automaton.add_transition((q0, "a", q1))
+        automaton.add_transition((q0, "b", q2))
+        automaton.add_transition((q1, "c", q3))
+        automaton.add_transition((q2, "c", q3))
+        automaton.add_transition((q3, "c", q4))
+        automaton.add_transition((q4, "c", q4))
+
+        cls.minimized = automaton.minimize()
+
+    def test_states(self):
+        # the renaming of the states is non deterministic, so we need to compare every substructure.
+        assert self.minimized.size == 1
 
     @given(propositional_words(list("abc"), min_size=0, max_size=5))
     def test_accepts(self, word):


### PR DESCRIPTION
## Proposed changes

There is an issue when the automaton does not have any
accepting states, but several transitions among states.
The result is that, after the greatest-fixpoint computation,
during the building of the automaton, the algorithm tried
to add a non-deterministic transition, which make the
procedure to fail.

Fix that by normalizing the transitions before building the
automaton. "Normalize" here means to have only one guard
per edge.

## Fixes


## Types of changes

What types of changes does your code introduce to pythomata?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.md) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## Further comments
